### PR TITLE
Fix readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,7 @@ build:
     python: "3.12"
 
 sphinx:
-  configuration: docs/conf.py
+  configuration: docs/source/conf.py
 
 python:
   install:


### PR DESCRIPTION
We fix the readthedocs configuration; the path to `conf.py` has been wrong.